### PR TITLE
Don't export object as default, to increase compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ const cssValidator = {
 	validateText,
 };
 
-export default cssValidator;
+export = cssValidator;


### PR DESCRIPTION
Before this change, we were exporting the `cssValidator` object as the default object, which actually prevented it from being able to be required without adding `.default`:

```js
const cssValidator = require('w3c-css-validator').default;
```

This PR fixes that.