### PR TITLE
Write a contributing guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+<!-- Thanks for your interest in contributing! Please read the contributing guide (CONTRIBUTING.md) before submitting a PR. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,11 @@ _Note: if your commit messages are low quality, we’ll probably end up squash-m
 
 ## 9. Open a PR
 
-Visit your forked repository and open a new pull request. Make sure the source branch is the new branch you created, and the target branch is the `master` branch on this repository.
+Visit your forked repository and open a new pull request. Make sure the source branch is the new branch you created, and the target branch is the `master` branch on this repository (not the `master` branch on your forked repository).
 
 Try to describe the changes as best as you can in the description, including why you think the change is needed, how to take advantage of the change (if applicable), your design rationale, etc.
+
+If your PR closes one or more issues, write `Closes #X` for each in the PR description (`X` being the issue number).
 
 _Note: If your implementation or tests are incomplete, we recommend opening the pull request as a draft. This helps indicate there’s still more work left to be done._
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# How to contribute
+
+First of all, thanks for your willingness to help improve this project! 🎉
+
+We strive to make contributing to our open source projects easy, in part by following industry standard conventions and workflows, and by making testing and code formatting simple.
+
+_If you’ve never contributed to an open source project before, check out [this project](https://github.com/firstcontributions/first-contributions), which guides people through their first contribution._
+
+## A high-level overview
+
+From a high-level, here’s what the contribution process looks like:
+
+1. Choose something to contribute
+1. Fork this repository
+1. Prepare your local environment
+1. Make the proposed changes
+1. Test your changes
+1. Update the docs/README
+1. Format the code
+1. Commit your changes
+1. Open a PR
+1. Iterate through the review cycle
+1. Changes are accepted 🚀
+
+If you’ve contributed to open source projects before, this is probably a relatively familiar process. Let’s go over each step in more detail…
+
+## 1. Choose something to contribute
+
+Check out the issues tab if you don’t already have something in mind. We usually keep ideas for future improvements in there.
+
+Choose one cohesive thing to work on per PR, rather than lumping together unrelated changes.
+
+## 2. Fork this repository
+
+This one is pretty straight forward. If you’re not a designated collaborator on this project (usually reserved for Sparksuite engineers), you won’t be able to create a new branch inside _this_ repository. But, by forking the repository (making a copy in your own account or organization), you’ll be able to create a new branch in the forked repository and commit your proposed changes there.
+
+## 3. Prepare your local environment
+
+Start by cloning the forked repository, then create a new branch off of `master`. Check out that new branch, then hop over to your favorite terminal. At the root of the repository, run `yarn install --frozen-lockfile` to install dependencies.
+
+_Note: good branch names are usually succinct phrases that describe the change. So, for example, if a change fixes a typo in the README file, the branch name might read `fix-typo-in-readme`._
+
+## 4. Make the proposed changes
+
+Using the IDE of your choice, code your changes into existence. Try to follow the conventions and patterns already established in this codebase, particularly when it comes to commenting, spacing, naming, etc. Also, code readability and maintainability are very important; try to avoid “clever” code. During the review process, we’ll help catch anything that doesn’t look quite right.
+
+## 5. Test your changes
+
+You can do this by running `yarn test` at the root of the repository using your favorite terminal. All PRs have to pass every test before they can be accepted.
+
+If you’ve introduced functionality that isn’t already covered by a test, which is often the case, you should add appropriate test(s). If you don’t know where or how to add test(s), just skip this step for now and let us know you need help with this part when you open the PR.
+
+## 6. Update the docs/README
+
+Many, but not all, changes will require updates to the documentation and/or README. Take some time to update those as necessary so that they remain accurate and up-to-date.
+
+## 7. Format the code
+
+To standardize the code’s stylization into our preferred format, run `yarn format` at the root of the repository. Most problems can automatically be fixed, but if there are some that can’t be, go ahead and address those manually.
+
+## 8. Commit your changes
+
+Commit your changes to the new branch you created in your forked repository. For organization, you may want to break up your work into multiple commits. Try to use descriptive and succinct commit messages.
+
+_Note: if your commit messages are low quality, we’ll probably end up squash-merging your changes so that your commit messages don’t pollute the `master` branch’s commit history._
+
+## 9. Open a PR
+
+Visit your forked repository and open a new pull request. Make sure the source branch is the new branch you created, and the target branch is the `master` branch on this repository.
+
+Try to describe the changes as best as you can in the description, including why you think the change is needed, how to take advantage of the change (if applicable), your design rationale, etc.
+
+_Note: If your implementation or tests are incomplete, we recommend opening the pull request as a draft. This helps indicate there’s still more work left to be done._
+
+## 10. Iterate through the review cycle
+
+Opening a PR will notify Sparksuite’s engineers on Slack, and one of us will review your proposed contribution. If it’s not a good fit for our project, we’ll let you know why and will close the PR. Otherwise, we’ll leave feedback as necessary to help ensure the contribution meets our high standards of quality. Make any requested changes and then let us know when you want us to take another look.
+
+## 11. Changes are accepted 🚀
+
+Eventually, the PR will reach a point where we’re satisfied with the quality and we’ll incorporate your work into our project! The changes will usually be deployed with the next published release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Choose one cohesive thing to work on per PR, rather than lumping together unrela
 
 ## 2. Fork this repository
 
-This one is pretty straight forward. If you’re not a designated collaborator on this project (usually reserved for Sparksuite engineers), you won’t be able to create a new branch inside _this_ repository. But, by forking the repository (making a copy in your own account or organization), you’ll be able to create a new branch in the forked repository and commit your proposed changes there.
+This one is pretty straightforward. If you’re not a designated collaborator on this project (usually reserved for Sparksuite engineers), you won’t be able to create a new branch inside _this_ repository. But, by forking the repository (making a copy in your own account or organization), you’ll be able to create a new branch in the forked repository and commit your proposed changes there.
 
 ## 3. Prepare your local environment
 
@@ -56,7 +56,7 @@ Many, but not all, changes will require updates to the documentation and/or READ
 
 ## 7. Format the code
 
-To standardize the code’s stylization into our preferred format, run `yarn format` at the root of the repository. Most problems can automatically be fixed, but if there are some that can’t be, go ahead and address those manually.
+To standardize the code’s stylization into our preferred format, run `yarn format` at the root of the repository. Most problems can automatically be fixed, but if some can’t, go ahead and address those manually.
 
 ## 8. Commit your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ From a high-level, here’s what the contribution process looks like:
 1. Iterate through the review cycle
 1. Changes are accepted 🚀
 
-If you’ve contributed to open source projects before, this is probably a relatively familiar process. Let’s go over each step in more detail…
+It looks like a lot of steps, but it’s actually pretty easy. If you’ve contributed to open source projects before, it’s probably a familiar process. Let’s go over each step in more detail…
 
 ## 1. Choose something to contribute
 

--- a/README.md
+++ b/README.md
@@ -110,11 +110,3 @@ From W3C’s [manual](https://jigsaw.w3.org/css-validator/manual.html):
 You should not call the validator more often than **1 req/sec**. From W3C’s [manual](https://jigsaw.w3.org/css-validator/manual.html):
 
 > If you wish to call the validator programmatically for a batch of documents, please make sure that your script will sleep for at least 1 second between requests. The CSS Validation service is a free, public service for all, your respect is appreciated.
-
-## Local development
-
-To test the whole project, run `yarn test`.
-
-To format the code, run `yarn format`.
-
-To clean the repository (removes any programmatically generated files), run `yarn clean`.


### PR DESCRIPTION
This introduces a new `CONTRIBUTING.md` file at the root of the repository, with a guide on how to contribute to our open source project. I also removed some text from the `README.md` file, since it's now covered in the contributing guide.

I wrote the guide in a way that would work for all of our actively-maintained open source projects, so that we can easily copy-and-paste the content into each. Not all of our public repositories currently accept contributions, so I didn't want to make it an organization-wide file.

I also added a PR template to point people to the contributing guide, if they don't notice GitHub's prompts.