### PR TITLE
Remove unwanted characters from error messages

### DIFF
--- a/src/validate-text.ts
+++ b/src/validate-text.ts
@@ -115,7 +115,7 @@ async function validateText(textToBeValidated: string, options?: ValidateTextOpt
 	cssValidationResponse.errors?.forEach((error) => {
 		result.errors.push({
 			line: error.line,
-			message: error.message.replace(' : ', '').trim(),
+			message: error.message.replace(/[ :]+$/, '').trim(),
 		});
 	});
 

--- a/src/validate-text.ts
+++ b/src/validate-text.ts
@@ -123,7 +123,7 @@ async function validateText(textToBeValidated: string, options?: ValidateTextOpt
 		cssValidationResponse.warnings?.forEach((warning) => {
 			result.warnings.push({
 				line: warning.line,
-				message: warning.message.replace(' : ', '').trim(),
+				message: warning.message.replace(/[ :]+$/, '').trim(),
 				level: (warning.level + 1) as 1 | 2 | 3,
 			});
 		});

--- a/src/validate-text.ts
+++ b/src/validate-text.ts
@@ -115,7 +115,7 @@ async function validateText(textToBeValidated: string, options?: ValidateTextOpt
 	cssValidationResponse.errors?.forEach((error) => {
 		result.errors.push({
 			line: error.line,
-			message: error.message,
+			message: error.message.replace(' : ', '').trim(),
 		});
 	});
 
@@ -123,7 +123,7 @@ async function validateText(textToBeValidated: string, options?: ValidateTextOpt
 		cssValidationResponse.warnings?.forEach((warning) => {
 			result.warnings.push({
 				line: warning.line,
-				message: warning.message,
+				message: warning.message.replace(' : ', '').trim(),
 				level: (warning.level + 1) as 1 | 2 | 3,
 			});
 		});

--- a/tests/jest/index.test.ts
+++ b/tests/jest/index.test.ts
@@ -91,6 +91,8 @@ describe('#validateText()', () => {
 		const result = await cssValidator.validateText('.foo { foo: bar; }');
 
 		expect(result.errors.length).toBeGreaterThan(0);
-		expect(result.errors.some((error) => error.message.includes(' : '))).toBe(false);
+		for (const error of result.errors) {
+			expect(error).not.toMatch(/ : /);
+		}
 	});
 });

--- a/tests/jest/index.test.ts
+++ b/tests/jest/index.test.ts
@@ -86,4 +86,11 @@ describe('#validateText()', () => {
 			'The warning level must be one of the following:'
 		);
 	});
+
+	it('Parses out unwanted characters from error messages', async () => {
+		const result = await cssValidator.validateText('.foo { foo: bar; }');
+
+		expect(result.errors.length).toBeGreaterThan(0);
+		expect(result.errors.some((error) => error.message.includes(' : '))).toBe(false);
+	});
 });


### PR DESCRIPTION
This pull request removes characters provided in many error messages return by the W3C Validator API, that are implementation specific.

Closes #40 