### PR TITLE
Fix the appearance of the "Get started" button

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -64,7 +64,7 @@ const Home: React.FC = () => {
 					<h1 className='hero__title'>{siteConfig.title}</h1>
 					<p className='hero__subtitle'>{siteConfig.tagline}</p>
 					<div className={styles.buttons}>
-						<Link className={clsx('button button--outline button--lg', styles.getStarted)} to={useBaseUrl('docs/')}>
+						<Link className={clsx('button button--lg', styles.getStarted)} to={useBaseUrl('docs/')}>
 							Get started
 						</Link>
 					</div>

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -35,3 +35,7 @@
 	height: 200px;
 	width: 200px;
 }
+
+.getStarted {
+	border: 1px solid #fff;
+}


### PR DESCRIPTION
Oddly, in development mode (running `yarn start`) the "Get started" button looked just fine:

<img width="212" alt="Screen Shot 2021-03-01 at 7 44 40 AM" src="https://user-images.githubusercontent.com/3850064/109505211-fb367a80-7a61-11eb-9d61-58c4f1919b82.png">

But, in production, it looked like:

<img width="183" alt="Screen Shot 2021-03-01 at 7 44 53 AM" src="https://user-images.githubusercontent.com/3850064/109505250-04274c00-7a62-11eb-8e9e-6e31308f5730.png">

This change should fix that.