### PR TITLE
Apply a handy global Jest option

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,6 +2,7 @@ import type { Config } from '@jest/types';
 
 const config: Config.InitialOptions = {
 	displayName: 'Test suite',
+	clearMocks: true,
 	collectCoverage: true,
 	coverageDirectory: './coverage/',
 	collectCoverageFrom: ['<rootDir>/src/**/*.ts'],


### PR DESCRIPTION
This enables a Jest option we usually make use of during our testing. It's consistent with our other OSS projects.