### PR TITLE
Fix linked package

### DIFF
--- a/rugged.config.ts
+++ b/rugged.config.ts
@@ -1,0 +1,7 @@
+// import { Config } from 'rugged';
+
+// const config: Config = {
+//     // TODO
+// };
+
+// export default config;

--- a/rugged.config.ts
+++ b/rugged.config.ts
@@ -1,7 +1,0 @@
-// import { Config } from 'rugged';
-
-// const config: Config = {
-//     // TODO
-// };
-
-// export default config;

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
 		"clsx": "^1.1.1",
 		"react": "^17.0.1",
 		"react-dom": "^17.0.1",
-		"w3c-css-validator": "../"
+		"w3c-css-validator": "link:../"
 	},
 	"browserslist": {
 		"production": [

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
 		"clsx": "^1.1.1",
 		"react": "^17.0.1",
 		"react-dom": "^17.0.1",
-		"w3c-css-validator": "link:../"
+		"w3c-css-validator": "../"
 	},
 	"browserslist": {
 		"production": [

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -9868,7 +9868,7 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-"w3c-css-validator@link:../":
+"w3c-css-validator@link:..":
   version "0.0.0"
   uid ""
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -9868,8 +9868,9 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-w3c-css-validator@../:
-  version "1.0.3"
+"w3c-css-validator@link:../":
+  version "0.0.0"
+  uid ""
 
 wait-on@^5.2.1:
   version "5.2.1"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -9868,9 +9868,8 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-"w3c-css-validator@link:../":
-  version "0.0.0"
-  uid ""
+w3c-css-validator@../:
+  version "1.0.3"
 
 wait-on@^5.2.1:
   version "5.2.1"


### PR DESCRIPTION
This fixes the method of linking the root package from the `website/` directory. It should have contained a `link:` prefix. This addresses issues with conflicts that can arise, and significantly speeds up Yarn operations.