### PR TITLE
Introduce CSS files for testing remote urls with validator

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ build/
 .docusaurus/
 babel.config.js
 jest-puppeteer.config.js
+public/css/error.css

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ coverage/
 dist/
 build/
 .docusaurus/
+public/css/error.css

--- a/public/css/error.css
+++ b/public/css/error.css
@@ -1,0 +1,1 @@
+.foo { text-align: center; 

--- a/public/css/valid.css
+++ b/public/css/valid.css
@@ -1,0 +1,3 @@
+.foo {
+	text-align: center;
+}

--- a/public/css/warning.css
+++ b/public/css/warning.css
@@ -1,0 +1,3 @@
+.foo {
+	font-family: Georgia;
+}


### PR DESCRIPTION
This pull request introduces three css files for later use in testing urls as the source for the CSS to validate  with the W3C CSS Validator.
