### PR TITLE
Fixed CSS meant to generate errors being valid in CSS3

### DIFF
--- a/public/css/error.css
+++ b/public/css/error.css
@@ -1,1 +1,1 @@
-.foo { text-align: center; 
+.foo { text-align: invalid-value; }

--- a/src/validate-text.test.ts
+++ b/src/validate-text.test.ts
@@ -27,7 +27,7 @@ export default function testValidateText(validateText: ValidateText): void {
 		});
 
 		it('Includes errors present in the response on the result', async () => {
-			expect(await validateText('.foo { text-align: center; ')).toStrictEqual({
+			expect(await validateText('.foo { text-align: invalid-value; }')).toStrictEqual({
 				valid: false,
 				errors: [
 					{

--- a/test-projects/browser/index.test.ts
+++ b/test-projects/browser/index.test.ts
@@ -41,7 +41,7 @@ it('Returns the validity', async () => {
 });
 
 it('Includes errors present in the response on the result', async () => {
-	await page.type('#custom-css', '.foo { text-align: center; ');
+	await page.type('#custom-css', '.foo { text-align: invalid-value; }');
 	await page.click('#make-call');
 
 	await waitForResponse({ expectErrors: true });


### PR DESCRIPTION
This merge request changes the CSS meant to be invalid to be invalid in CSS3 and likely future versions.

Closes #87 

