### PR TITLE
Implement `validateURL`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w3c-css-validator",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Easily validate CSS using W3C's public CSS validator service",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/build-request-url.test.ts
+++ b/src/build-request-url.test.ts
@@ -15,10 +15,10 @@ describe('#buildRequestURL()', () => {
 		);
 	});
 
-	it('Handles parameters with uri value', () => {
+	it('Handles parameters with URL value', () => {
 		expect(
 			buildRequestURL({
-				uri: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
+				url: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
 				medium: undefined,
 				warningLevel: undefined,
 			})
@@ -39,17 +39,17 @@ describe('#buildRequestURL()', () => {
 		);
 	});
 
-	it('Complains if text and uri values are provided simultaneously', () => {
+	it('Complains if text and URL values are provided simultaneously', () => {
 		expect(() =>
 			buildRequestURL(
-				// @ts-expect-error: We're trying to force an error here
 				{
 					text: '.foo { text-align: center; }',
-					uri: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
+					// @ts-expect-error: We're trying to force an error here
+					url: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
 					medium: undefined,
 					warningLevel: undefined,
 				}
 			)
-		).toThrow('Only a text or a URI value can be provided');
+		).toThrow('Only a text or a URL value can be provided');
 	});
 });

--- a/src/build-request-url.test.ts
+++ b/src/build-request-url.test.ts
@@ -41,15 +41,13 @@ describe('#buildRequestURL()', () => {
 
 	it('Complains if text and URL values are provided simultaneously', () => {
 		expect(() =>
-			buildRequestURL(
-				{
-					text: '.foo { text-align: center; }',
-					// @ts-expect-error: We're trying to force an error here
-					url: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
-					medium: undefined,
-					warningLevel: undefined,
-				}
-			)
+			buildRequestURL({
+				text: '.foo { text-align: center; }',
+				// @ts-expect-error: We're trying to force an error here
+				url: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
+				medium: undefined,
+				warningLevel: undefined,
+			})
 		).toThrow('Only a text or a URL value can be provided');
 	});
 });

--- a/src/build-request-url.test.ts
+++ b/src/build-request-url.test.ts
@@ -1,0 +1,55 @@
+// Imports
+import buildRequestURL from './build-request-url';
+
+// Tests
+describe('#buildRequestURL()', () => {
+	it('Handles parameters with text value', () => {
+		expect(
+			buildRequestURL({
+				text: '.foo { text-align: center; }',
+				medium: undefined,
+				warningLevel: undefined,
+			})
+		).toBe(
+			'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3'
+		);
+	});
+
+	it('Handles parameters with uri value', () => {
+		expect(
+			buildRequestURL({
+				uri: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
+				medium: undefined,
+				warningLevel: undefined,
+			})
+		).toBe(
+			'https://jigsaw.w3.org/css-validator/validator?uri=https%3A%2F%2Fraw.githubusercontent.com%2Fsparksuite%2Fw3c-css-validator%2Fmaster%2Fpublic%2Fcss%2Fvalid.css&usermedium=all&warning=no&output=application/json&profile=css3'
+		);
+	});
+
+	it('Uses provided parameters over default values', () => {
+		expect(
+			buildRequestURL({
+				text: '.foo { text-align: center; }',
+				medium: 'braille',
+				warningLevel: 3,
+			})
+		).toBe(
+			'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=braille&warning=2&output=application/json&profile=css3'
+		);
+	});
+
+	it('Complains if text and uri values are provided simultaneously', () => {
+		expect(() =>
+			buildRequestURL(
+				// @ts-expect-error: We're trying to force an error here
+				{
+					text: '.foo { text-align: center; }',
+					uri: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
+					medium: undefined,
+					warningLevel: undefined,
+				}
+			)
+		).toThrow('Only a text or a URI value can be provided');
+	});
+});

--- a/src/build-request-url.ts
+++ b/src/build-request-url.ts
@@ -4,8 +4,8 @@ import { Parameters } from './types/parameters';
 // Helper function that takes in parameters and builds a URL to make a request with
 function buildRequestURL(parameters: Parameters): string {
 	// Validate input
-	if ('text' in parameters && 'uri' in parameters) {
-		throw new Error('Only a text or a URI value can be provided');
+	if ('text' in parameters && 'url' in parameters) {
+		throw new Error('Only a text or a URL value can be provided');
 	}
 
 	// Return request URL
@@ -15,7 +15,7 @@ function buildRequestURL(parameters: Parameters): string {
 					text: encodeURIComponent(parameters.text),
 			  }
 			: {
-					uri: encodeURIComponent(parameters.uri),
+					uri: encodeURIComponent(parameters.url),
 			  }),
 		usermedium: parameters?.medium ?? 'all',
 		warning: parameters?.warningLevel ? parameters.warningLevel - 1 : 'no',

--- a/src/build-request-url.ts
+++ b/src/build-request-url.ts
@@ -1,0 +1,31 @@
+// Imports
+import { Parameters } from './types/parameters';
+
+// Helper function that takes in parameters and builds a URL to make a request with
+function buildRequestURL(parameters: Parameters): string {
+	// Validate input
+	if ('text' in parameters && 'uri' in parameters) {
+		throw new Error('Only a text or a URI value can be provided');
+	}
+
+	// Return request URL
+	const params = {
+		...('text' in parameters && parameters.text !== undefined
+			? {
+					text: encodeURIComponent(parameters.text),
+			  }
+			: {
+					uri: encodeURIComponent(parameters.uri),
+			  }),
+		usermedium: parameters?.medium ?? 'all',
+		warning: parameters?.warningLevel ? parameters.warningLevel - 1 : 'no',
+		output: 'application/json',
+		profile: 'css3',
+	};
+
+	return `https://jigsaw.w3.org/css-validator/validator?${Object.entries(params)
+		.map(([key, val]) => `${key}=${val}`)
+		.join('&')}`;
+}
+
+export default buildRequestURL;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 // Imports
 import validateText from './validate-text';
+import validateURL from './validate-url';
 
 // Validates CSS using W3C's public CSS validator service
 const cssValidator = {
 	validateText,
+	validateURL,
 };
 
 export = cssValidator;

--- a/src/retrieve-validation/index.ts
+++ b/src/retrieve-validation/index.ts
@@ -9,11 +9,13 @@ export interface W3CCSSValidatorResponse {
 		errors?: {
 			line: number;
 			message: string;
+			source?: string;
 		}[];
 		warnings?: {
 			line: number;
 			level: 0 | 1 | 2;
 			message: string;
+			source?: string;
 		}[];
 	};
 }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,0 +1,14 @@
+interface OptionsBase {
+	medium?: 'all' | 'braille' | 'embossed' | 'handheld' | 'print' | 'projection' | 'screen' | 'speech' | 'tty' | 'tv';
+	timeout?: number;
+}
+
+export interface OptionsWithoutWarnings extends OptionsBase {
+	warningLevel?: 0;
+}
+
+export interface OptionsWithWarnings extends OptionsBase {
+	warningLevel: 1 | 2 | 3;
+}
+
+export type Options = OptionsWithWarnings | OptionsWithoutWarnings;

--- a/src/types/parameters.ts
+++ b/src/types/parameters.ts
@@ -10,9 +10,9 @@ interface TextParameters extends ParametersBase {
 	uri?: never;
 }
 
-interface URIParameters extends ParametersBase {
-	uri: string;
+interface URLParameters extends ParametersBase {
+	url: string;
 	text?: never;
 }
 
-export type Parameters = TextParameters | URIParameters;
+export type Parameters = TextParameters | URLParameters;

--- a/src/types/parameters.ts
+++ b/src/types/parameters.ts
@@ -1,0 +1,18 @@
+import { Options } from './options';
+
+interface ParametersBase {
+	medium: Options['medium'];
+	warningLevel: Options['warningLevel'];
+}
+
+interface TextParameters extends ParametersBase {
+	text: string;
+	uri?: never;
+}
+
+interface URIParameters extends ParametersBase {
+	uri: string;
+	text?: never;
+}
+
+export type Parameters = TextParameters | URIParameters;

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -19,3 +19,27 @@ export interface ValidateTextResultWithoutWarnings extends ValidateTextResultBas
 }
 
 export type ValidateTextResult = ValidateTextResultWithWarnings | ValidateTextResultWithoutWarnings;
+
+export interface ValidateURLResultBase {
+	valid: boolean;
+	errors: {
+		line: number;
+		url: string | null;
+		message: string;
+	}[];
+}
+
+export interface ValidateURLResultWithWarnings extends ValidateURLResultBase {
+	warnings: {
+		line: number;
+		url: string | null;
+		level: 1 | 2 | 3;
+		message: string;
+	}[];
+}
+
+export interface ValidateURLResultWithoutWarnings extends ValidateURLResultBase {
+	warnings?: never;
+}
+
+export type ValidateURLResult = ValidateURLResultWithWarnings | ValidateURLResultWithoutWarnings;

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,0 +1,21 @@
+export interface ValidateTextResultBase {
+	valid: boolean;
+	errors: {
+		line: number;
+		message: string;
+	}[];
+}
+
+export interface ValidateTextResultWithWarnings extends ValidateTextResultBase {
+	warnings: {
+		line: number;
+		level: 1 | 2 | 3;
+		message: string;
+	}[];
+}
+
+export interface ValidateTextResultWithoutWarnings extends ValidateTextResultBase {
+	warnings?: never;
+}
+
+export type ValidateTextResult = ValidateTextResultWithWarnings | ValidateTextResultWithoutWarnings;

--- a/src/validate-options.test.ts
+++ b/src/validate-options.test.ts
@@ -1,0 +1,38 @@
+// Imports
+import validateOptions from './validate-options';
+
+// Tests
+describe('#validateOptions()', () => {
+	it('Ignores no options', async () => {
+		expect(() => validateOptions(undefined)).not.toThrow();
+	});
+
+	it('Ignores valid options', async () => {
+		expect(() =>
+			validateOptions({
+				medium: 'braille',
+				warningLevel: 1,
+				timeout: 1000,
+			})
+		).not.toThrow();
+	});
+
+	it('Complains about invalid medium', async () => {
+		// @ts-expect-error: We're trying to force an error here
+		expect(() => validateOptions({ medium: 'fake' })).toThrow('The medium must be one of the following:');
+	});
+
+	it('Complains about invalid warning level', async () => {
+		// @ts-expect-error: We're trying to force an error here
+		expect(() => validateOptions({ warningLevel: 'fake' })).toThrow('The warning level must be one of the following:');
+	});
+
+	it('Complains about negative timeout', async () => {
+		expect(() => validateOptions({ timeout: -1 })).toThrow('The timeout must be a positive integer');
+	});
+
+	it('Complains about non-integer times', async () => {
+		expect(() => validateOptions({ timeout: Infinity })).toThrow('The timeout must be an integer');
+		expect(() => validateOptions({ timeout: 400.1 })).toThrow('The timeout must be an integer');
+	});
+});

--- a/src/validate-options.ts
+++ b/src/validate-options.ts
@@ -1,0 +1,45 @@
+// Imports
+import { Options } from './types/options';
+
+// Define supported mediums
+const allowedMediums: Options['medium'][] = [
+	'all',
+	'braille',
+	'embossed',
+	'handheld',
+	'print',
+	'projection',
+	'screen',
+	'speech',
+	'tty',
+	'tv',
+];
+
+// Define supported warning levels
+const allowedWarningLevels: Options['warningLevel'][] = [0, 1, 2, 3];
+
+// Helper function that validates the supported options
+function validateOptions(options?: Options): void {
+	if (options) {
+		// Validate medium option
+		if (options.medium && !allowedMediums.includes(options.medium)) {
+			throw new Error(`The medium must be one of the following: ${allowedMediums.join(', ')}`);
+		}
+
+		// Validate warning level option
+		if (options.warningLevel && !allowedWarningLevels.includes(options.warningLevel)) {
+			throw new Error(`The warning level must be one of the following: ${allowedWarningLevels.join(', ')}`);
+		}
+
+		// Validate timeout option
+		if (options.timeout !== undefined && !Number.isInteger(options.timeout)) {
+			throw new Error('The timeout must be an integer');
+		}
+
+		if (options.timeout && options.timeout < 0) {
+			throw new Error('The timeout must be a positive integer');
+		}
+	}
+}
+
+export default validateOptions;

--- a/src/validate-text.test.ts
+++ b/src/validate-text.test.ts
@@ -77,27 +77,6 @@ export default function testValidateText(validateText: ValidateText): void {
 			await expect(validateText(true)).rejects.toThrow('The text to be validated must be a string');
 		});
 
-		it('Complains about invalid medium', async () => {
-			// @ts-expect-error: We're trying to force an error here
-			await expect(validateText('abc', { medium: 'fake' })).rejects.toThrow('The medium must be one of the following:');
-		});
-
-		it('Complains about invalid warning level', async () => {
-			// @ts-expect-error: We're trying to force an error here
-			await expect(validateText('abc', { warningLevel: 'fake' })).rejects.toThrow(
-				'The warning level must be one of the following:'
-			);
-		});
-
-		it('Complains about negative timeout', async () => {
-			await expect(validateText('abc', { timeout: -1 })).rejects.toThrow('The timeout must be a positive integer');
-		});
-
-		it('Complains about non-integer times', async () => {
-			await expect(validateText('abc', { timeout: Infinity })).rejects.toThrow('The timeout must be an integer');
-			await expect(validateText('abc', { timeout: 400.1 })).rejects.toThrow('The timeout must be an integer');
-		});
-
 		it('Throws when the timeout is passed', async () => {
 			await expect(validateText('abc', { timeout: 1 })).rejects.toThrow('The request took longer than 1ms');
 		});

--- a/src/validate-url.test.ts
+++ b/src/validate-url.test.ts
@@ -12,14 +12,23 @@ export default function testValidateURL(validateURL: ValidateURL): void {
 		);
 
 		it('Returns the validity and errors when no options are provided', async () => {
-			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/valid.css')).toStrictEqual({
+			expect(
+				await validateURL(
+					'https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/valid.css'
+				)
+			).toStrictEqual({
 				valid: true,
 				errors: [],
 			});
 		});
 
 		it('Returns the validity, errors, and warnings when a warning level option is provided', async () => {
-			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/valid.css', { warningLevel: 1 })).toStrictEqual({
+			expect(
+				await validateURL(
+					'https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/valid.css',
+					{ warningLevel: 1 }
+				)
+			).toStrictEqual({
 				valid: true,
 				errors: [],
 				warnings: [],
@@ -27,7 +36,11 @@ export default function testValidateURL(validateURL: ValidateURL): void {
 		});
 
 		it('Includes errors present in the response on the result', async () => {
-			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/76341fda26fd16021155ea853d6e4d7db0e194c4/public/css/error.css')).toStrictEqual({
+			expect(
+				await validateURL(
+					'https://rawcdn.githack.com/sparksuite/w3c-css-validator/76341fda26fd16021155ea853d6e4d7db0e194c4/public/css/error.css'
+				)
+			).toStrictEqual({
 				valid: false,
 				errors: [
 					{
@@ -42,7 +55,12 @@ export default function testValidateURL(validateURL: ValidateURL): void {
 		});
 
 		it('Includes warnings present in the response on the result when options specify a warning level', async () => {
-			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css', { warningLevel: 3 })).toStrictEqual({
+			expect(
+				await validateURL(
+					'https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css',
+					{ warningLevel: 3 }
+				)
+			).toStrictEqual({
 				valid: true,
 				errors: [],
 				warnings: [
@@ -59,12 +77,21 @@ export default function testValidateURL(validateURL: ValidateURL): void {
 		});
 
 		it('Does not include warnings on the result when warnings aren’t enabled', async () => {
-			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css')).toStrictEqual({
+			expect(
+				await validateURL(
+					'https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css'
+				)
+			).toStrictEqual({
 				valid: true,
 				errors: [],
 			});
 
-			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css', { warningLevel: 0 })).toStrictEqual({
+			expect(
+				await validateURL(
+					'https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css',
+					{ warningLevel: 0 }
+				)
+			).toStrictEqual({
 				valid: true,
 				errors: [],
 			});
@@ -82,11 +109,18 @@ export default function testValidateURL(validateURL: ValidateURL): void {
 		});
 
 		it('Throws when the timeout is passed', async () => {
-			await expect(validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/valid.css', { timeout: 1 })).rejects.toThrow('The request took longer than 1ms');
+			await expect(
+				validateURL(
+					'https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/valid.css',
+					{ timeout: 1 }
+				)
+			).rejects.toThrow('The request took longer than 1ms');
 		});
 
 		it('Parses out unwanted characters from error messages', async () => {
-			const result = await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/76341fda26fd16021155ea853d6e4d7db0e194c4/public/css/error.css');
+			const result = await validateURL(
+				'https://rawcdn.githack.com/sparksuite/w3c-css-validator/76341fda26fd16021155ea853d6e4d7db0e194c4/public/css/error.css'
+			);
 
 			expect(result.errors.length).toBeGreaterThan(0);
 			for (const error of result.errors) {

--- a/src/validate-url.test.ts
+++ b/src/validate-url.test.ts
@@ -1,0 +1,95 @@
+// Imports
+import validateURL from './validate-url';
+
+// Define the type separately so names don't conflict
+type ValidateURL = typeof validateURL;
+
+// Export this function so we can use it elsewhere
+export default function testValidateURL(validateURL: ValidateURL): void {
+	describe('#validateURL()', () => {
+		afterEach(
+			() => new Promise<void>((resolve) => setTimeout(resolve, 1000))
+		);
+
+		it('Returns the validity and errors when no options are provided', async () => {
+			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/valid.css')).toStrictEqual({
+				valid: true,
+				errors: [],
+			});
+		});
+
+		it('Returns the validity, errors, and warnings when a warning level option is provided', async () => {
+			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/valid.css', { warningLevel: 1 })).toStrictEqual({
+				valid: true,
+				errors: [],
+				warnings: [],
+			});
+		});
+
+		it('Includes errors present in the response on the result', async () => {
+			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/error.css')).toStrictEqual({
+				valid: false,
+				errors: [
+					{
+						line: 1,
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+						message: expect.any(String),
+					},
+				],
+			});
+		});
+
+		it('Includes warnings present in the response on the result when options specify a warning level', async () => {
+			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css', { warningLevel: 3 })).toStrictEqual({
+				valid: true,
+				errors: [],
+				warnings: [
+					{
+						level: 3,
+						line: 1,
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+						message: expect.any(String),
+					},
+				],
+			});
+		});
+
+		it('Does not include warnings on the result when warnings aren’t enabled', async () => {
+			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css')).toStrictEqual({
+				valid: true,
+				errors: [],
+			});
+
+			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css', { warningLevel: 0 })).toStrictEqual({
+				valid: true,
+				errors: [],
+			});
+		});
+
+		it('Complains about missing URL', async () => {
+			// @ts-expect-error: We're trying to force an error here
+			await expect(validateURL()).rejects.toThrow('You must pass in a URL to be validated');
+			await expect(validateURL('')).rejects.toThrow('You must pass in a URL to be validated');
+		});
+
+		it('Complains about URL not being a string', async () => {
+			// @ts-expect-error: We're trying to force an error here
+			await expect(validateURL(true)).rejects.toThrow('The URL to be validated must be a string');
+		});
+
+		it('Throws when the timeout is passed', async () => {
+			await expect(validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/valid.css', { timeout: 1 })).rejects.toThrow('The request took longer than 1ms');
+		});
+
+		it('Parses out unwanted characters from error messages', async () => {
+			const result = await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/error.css');
+
+			expect(result.errors.length).toBeGreaterThan(0);
+			for (const error of result.errors) {
+				expect(error.message).not.toMatch(/ : /);
+			}
+		});
+	});
+}
+
+testValidateURL(validateURL);

--- a/src/validate-url.test.ts
+++ b/src/validate-url.test.ts
@@ -27,13 +27,15 @@ export default function testValidateURL(validateURL: ValidateURL): void {
 		});
 
 		it('Includes errors present in the response on the result', async () => {
-			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/error.css')).toStrictEqual({
+			expect(await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/76341fda26fd16021155ea853d6e4d7db0e194c4/public/css/error.css')).toStrictEqual({
 				valid: false,
 				errors: [
 					{
 						line: 1,
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 						message: expect.any(String),
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+						url: expect.any(String),
 					},
 				],
 			});
@@ -46,9 +48,11 @@ export default function testValidateURL(validateURL: ValidateURL): void {
 				warnings: [
 					{
 						level: 3,
-						line: 1,
+						line: 2,
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 						message: expect.any(String),
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+						url: expect.any(String),
 					},
 				],
 			});
@@ -82,7 +86,7 @@ export default function testValidateURL(validateURL: ValidateURL): void {
 		});
 
 		it('Parses out unwanted characters from error messages', async () => {
-			const result = await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/error.css');
+			const result = await validateURL('https://rawcdn.githack.com/sparksuite/w3c-css-validator/76341fda26fd16021155ea853d6e4d7db0e194c4/public/css/error.css');
 
 			expect(result.errors.length).toBeGreaterThan(0);
 			for (const error of result.errors) {

--- a/src/validate-url.ts
+++ b/src/validate-url.ts
@@ -1,0 +1,81 @@
+// Imports
+import buildRequestURL from './build-request-url';
+import retrieveValidation from './retrieve-validation';
+import { OptionsWithoutWarnings, OptionsWithWarnings, Options } from './types/options';
+import {
+	ValidateURLResultWithoutWarnings,
+	ValidateURLResultWithWarnings,
+	ValidateURLResult,
+	ValidateURLResultBase,
+} from './types/result';
+import validateOptions from './validate-options';
+
+// Validates a string of CSS
+async function validateURL(
+	urlToBeValidated: string,
+	options?: OptionsWithoutWarnings
+): Promise<ValidateURLResultWithoutWarnings>;
+async function validateURL(
+	urlToBeValidated: string,
+	options: OptionsWithWarnings
+): Promise<ValidateURLResultWithWarnings>;
+async function validateURL(urlToBeValidated: string, options?: Options): Promise<ValidateURLResult> {
+	// Validations
+	if (!urlToBeValidated) {
+		throw new Error('You must pass in a URL to be validated');
+	}
+
+	if (typeof urlToBeValidated !== 'string') {
+		throw new Error('The URL to be validated must be a string');
+	}
+
+	validateOptions(options);
+
+	// Build URL for fetching
+	const url = buildRequestURL({
+		url: urlToBeValidated,
+		medium: options?.medium,
+		warningLevel: options?.warningLevel,
+	});
+
+	// Call W3C CSS Validator API and store response
+	const cssValidationResponse = await retrieveValidation(url, options?.timeout ?? 10000);
+
+	// Build result
+	const base: ValidateURLResultBase = {
+		valid: false,
+		errors: [],
+	};
+	const result: ValidateURLResultWithWarnings | ValidateURLResultBase = options?.warningLevel
+		? {
+				...base,
+				warnings: [],
+		  }
+		: base;
+
+	result.valid = cssValidationResponse.validity;
+
+	cssValidationResponse.errors?.forEach((error) => {
+		result.errors.push({
+			line: error.line,
+			message: error.message.replace(/[ :]+$/, '').trim(),
+            url: error.source ?? null,
+		});
+	});
+
+	if ('warnings' in result) {
+		cssValidationResponse.warnings?.forEach((warning) => {
+			result.warnings.push({
+				line: warning.line,
+				message: warning.message.replace(/[ :]+$/, '').trim(),
+				level: (warning.level + 1) as 1 | 2 | 3,
+                url: warning.source ?? null,
+			});
+		});
+	}
+
+	// Return
+	return result;
+}
+
+export default validateURL;

--- a/src/validate-url.ts
+++ b/src/validate-url.ts
@@ -59,7 +59,7 @@ async function validateURL(urlToBeValidated: string, options?: Options): Promise
 		result.errors.push({
 			line: error.line,
 			message: error.message.replace(/[ :]+$/, '').trim(),
-            url: error.source ?? null,
+			url: error.source ?? null,
 		});
 	});
 
@@ -69,7 +69,7 @@ async function validateURL(urlToBeValidated: string, options?: Options): Promise
 				line: warning.line,
 				message: warning.message.replace(/[ :]+$/, '').trim(),
 				level: (warning.level + 1) as 1 | 2 | 3,
-                url: warning.source ?? null,
+				url: warning.source ?? null,
 			});
 		});
 	}

--- a/test-projects/browser/index.html
+++ b/test-projects/browser/index.html
@@ -8,6 +8,10 @@
 
 	<body>
 		<div id="input">
+			<select id="method">
+				<option>validateText</option>
+				<option>validateURL</option>
+			</select>
 			<textarea id="custom-css"></textarea>
 			<select id="warning-level">
 				<option>0</option>

--- a/test-projects/browser/index.test.ts
+++ b/test-projects/browser/index.test.ts
@@ -13,62 +13,143 @@ const waitForResponse = async (options?: { expectErrors?: true; expectWarnings?:
 	}
 };
 
-// Setup work before each test
-beforeEach(async () => {
-	await jestPuppeteer.resetPage();
+// Tests
+describe('#validateText()', () => {
+	// Setup work before each test
+	beforeEach(async () => {
+		await jestPuppeteer.resetPage();
 
-	await page.goto(`http://localhost:8080/`, {
-		waitUntil: 'load',
+		await page.goto(`http://localhost:8080/`, {
+			waitUntil: 'load',
+		});
+
+		await page.select('#method', 'validateText');
+	});
+
+	// Wait after each test, see "Note" section under https://jigsaw.w3.org/css-validator/manual.html#expert
+	afterEach(
+		() => new Promise<void>((resolve) => setTimeout(resolve, 1000))
+	);
+
+	// Tests
+	it('Loads', async () => {
+		await expect(page.title()).resolves.toMatch('Hello world!');
+	});
+
+	it('Returns the validity', async () => {
+		await page.type('#custom-css', '.foo { text-align: center; }');
+		await page.click('#make-call');
+
+		await waitForResponse();
+		expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('true');
+	});
+
+	it('Includes errors present in the response on the result', async () => {
+		await page.type('#custom-css', '.foo { text-align: invalid-value; }');
+		await page.click('#make-call');
+
+		await waitForResponse({ expectErrors: true });
+		expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('false');
+		expect(
+			await page.evaluate(() => document.querySelector<HTMLUListElement>('#errors')?.childElementCount)
+		).toBeGreaterThan(0);
+	});
+
+	it('Includes warnings present in the response on the result when options specify a warning level', async () => {
+		await page.type('#custom-css', '.foo { font-family: Georgia; }');
+		await page.select('#warning-level', '3');
+		await page.click('#make-call');
+
+		await waitForResponse({ expectWarnings: true });
+		expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('true');
+		expect(
+			await page.evaluate(() => document.querySelector<HTMLUListElement>('#warnings')?.childElementCount)
+		).toBeGreaterThan(0);
+	});
+
+	it('Does not include warnings on the result when warnings aren’t enabled', async () => {
+		await page.type('#custom-css', '.foo { font-family: Georgia; }');
+		await page.select('#warning-level', '0');
+		await page.click('#make-call');
+
+		await waitForResponse();
+		expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('true');
+		expect(await page.evaluate(() => document.querySelector<HTMLUListElement>('#warnings')?.childElementCount)).toBe(0);
 	});
 });
 
-// Wait after each test, see "Note" section under https://jigsaw.w3.org/css-validator/manual.html#expert
-afterEach(
-	() => new Promise<void>((resolve) => setTimeout(resolve, 1000))
-);
+describe('#validateURL()', () => {
+	// Setup work before each test
+	beforeEach(async () => {
+		await jestPuppeteer.resetPage();
 
-// Tests
-it('Loads', async () => {
-	await expect(page.title()).resolves.toMatch('Hello world!');
-});
+		await page.goto(`http://localhost:8080/`, {
+			waitUntil: 'load',
+		});
 
-it('Returns the validity', async () => {
-	await page.type('#custom-css', '.foo { text-align: center; }');
-	await page.click('#make-call');
+		await page.select('#method', 'validateURL');
+	});
 
-	await waitForResponse();
-	expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('true');
-});
+	// Wait after each test, see "Note" section under https://jigsaw.w3.org/css-validator/manual.html#expert
+	afterEach(
+		() => new Promise<void>((resolve) => setTimeout(resolve, 1000))
+	);
 
-it('Includes errors present in the response on the result', async () => {
-	await page.type('#custom-css', '.foo { text-align: invalid-value; }');
-	await page.click('#make-call');
+	// Tests
+	it('Loads', async () => {
+		await expect(page.title()).resolves.toMatch('Hello world!');
+	});
 
-	await waitForResponse({ expectErrors: true });
-	expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('false');
-	expect(
-		await page.evaluate(() => document.querySelector<HTMLUListElement>('#errors')?.childElementCount)
-	).toBeGreaterThan(0);
-});
+	it('Returns the validity', async () => {
+		await page.type(
+			'#custom-css',
+			'https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/valid.css'
+		);
+		await page.click('#make-call');
 
-it('Includes warnings present in the response on the result when options specify a warning level', async () => {
-	await page.type('#custom-css', '.foo { font-family: Georgia; }');
-	await page.select('#warning-level', '3');
-	await page.click('#make-call');
+		await waitForResponse();
+		expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('true');
+	});
 
-	await waitForResponse({ expectWarnings: true });
-	expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('true');
-	expect(
-		await page.evaluate(() => document.querySelector<HTMLUListElement>('#warnings')?.childElementCount)
-	).toBeGreaterThan(0);
-});
+	it('Includes errors present in the response on the result', async () => {
+		await page.type(
+			'#custom-css',
+			'https://rawcdn.githack.com/sparksuite/w3c-css-validator/76341fda26fd16021155ea853d6e4d7db0e194c4/public/css/error.css'
+		);
+		await page.click('#make-call');
 
-it('Does not include warnings on the result when warnings aren’t enabled', async () => {
-	await page.type('#custom-css', '.foo { font-family: Georgia; }');
-	await page.select('#warning-level', '0');
-	await page.click('#make-call');
+		await waitForResponse({ expectErrors: true });
+		expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('false');
+		expect(
+			await page.evaluate(() => document.querySelector<HTMLUListElement>('#errors')?.childElementCount)
+		).toBeGreaterThan(0);
+	});
 
-	await waitForResponse();
-	expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('true');
-	expect(await page.evaluate(() => document.querySelector<HTMLUListElement>('#warnings')?.childElementCount)).toBe(0);
+	it('Includes warnings present in the response on the result when options specify a warning level', async () => {
+		await page.type(
+			'#custom-css',
+			'https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css'
+		);
+		await page.select('#warning-level', '3');
+		await page.click('#make-call');
+
+		await waitForResponse({ expectWarnings: true });
+		expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('true');
+		expect(
+			await page.evaluate(() => document.querySelector<HTMLUListElement>('#warnings')?.childElementCount)
+		).toBeGreaterThan(0);
+	});
+
+	it('Does not include warnings on the result when warnings aren’t enabled', async () => {
+		await page.type(
+			'#custom-css',
+			'https://rawcdn.githack.com/sparksuite/w3c-css-validator/6cf7b194b4f0b246678ed5101a2b6f0fb2918361/public/css/warning.css'
+		);
+		await page.select('#warning-level', '0');
+		await page.click('#make-call');
+
+		await waitForResponse();
+		expect(await page.evaluate(() => document.querySelector<HTMLHeadingElement>('#is-valid')?.innerText)).toBe('true');
+		expect(await page.evaluate(() => document.querySelector<HTMLUListElement>('#warnings')?.childElementCount)).toBe(0);
+	});
 });

--- a/test-projects/browser/src/index.ts
+++ b/test-projects/browser/src/index.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment */
 // Imports
 import cssValidator from 'w3c-css-validator';
-import { ValidateTextResultBase, ValidateTextResultWithWarnings } from '../../../dist/types';
+import {
+	ValidateTextResultBase,
+	ValidateTextResultWithWarnings,
+	ValidateURLResultBase,
+	ValidateURLResultWithWarnings,
+} from '../../../dist/types/result';
 
 // Wait until DOM content is available to attempt to make changes
 document.addEventListener('DOMContentLoaded', () => {
@@ -15,6 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	const errors = document.querySelector<HTMLUListElement>('#errors');
 	const warnings = document.querySelector<HTMLUListElement>('#warnings');
 	const warningLevelSelect = document.querySelector<HTMLSelectElement>('#warning-level');
+	const methodSelect = document.querySelector<HTMLSelectElement>('#method');
 
 	// Throw if any element is not present
 	if (!makeCall) {
@@ -41,8 +47,18 @@ document.addEventListener('DOMContentLoaded', () => {
 		throw new Error('Warning level select should be present');
 	}
 
+	if (!methodSelect) {
+		throw new Error('Method select should be present');
+	}
+
 	// Handle result
-	const handleResult = (result: ValidateTextResultBase | ValidateTextResultWithWarnings): void => {
+	const handleResult = (
+		result:
+			| ValidateTextResultBase
+			| ValidateTextResultWithWarnings
+			| ValidateURLResultBase
+			| ValidateURLResultWithWarnings
+	): void => {
 		isValid.innerText = String(result.valid);
 
 		result.errors.forEach((error) => {
@@ -65,17 +81,16 @@ document.addEventListener('DOMContentLoaded', () => {
 	// Handle makeCall clicks
 	makeCall.addEventListener('click', () => {
 		const warningLevel = Number(warningLevelSelect.value);
+		const method = methodSelect.value as keyof typeof cssValidator;
 
 		if (warningLevel > 0) {
-			cssValidator
-				.validateText(customCSS.value, { warningLevel: warningLevel as 1 | 2 | 3 })
+			cssValidator[method](customCSS.value, { warningLevel: warningLevel as 1 | 2 | 3 })
 				.then(handleResult)
 				.catch(() => {
 					throw new Error('Promise rejected');
 				});
 		} else {
-			cssValidator
-				.validateText(customCSS.value)
+			cssValidator[method](customCSS.value)
 				.then(handleResult)
 				.catch(() => {
 					throw new Error('Promise rejected');

--- a/test-projects/node/index.test.ts
+++ b/test-projects/node/index.test.ts
@@ -1,6 +1,8 @@
 // Imports
 import cssValidator from 'w3c-css-validator';
 import testValidateText from '../../src/validate-text.test';
+import testValidateURL from '../../src/validate-url.test';
 
 // Tests
 testValidateText(cssValidator.validateText);
+testValidateURL(cssValidator.validateURL);

--- a/website/docs/functions/validate-url.md
+++ b/website/docs/functions/validate-url.md
@@ -2,4 +2,57 @@
 title: validateURL()
 ---
 
-Interested in this capability? Help us bring it into existence by submitting a PR! https://github.com/sparksuite/w3c-css-validator/issues/31
+This function is used to validate external CSS via a URL.
+
+##  Options
+
+You can customize the behavior with options, passed as the second argument.
+
+Option | Default | Possible values
+:--- | :--- | :---
+`medium` | `all` | `all`, `braille`, `embossed`, `handheld`, `print`, `projection`, `screen`, `speech`, `tty`, `tv`
+`warningLevel` | `0` | `0`, `1`, `2`, `3`
+`timeout` | `10000` | `integer`
+
+Option | Explanation
+:--- | :---
+`medium` | The equivalent of the `@media` rule, applied to all of the CSS
+`warningLevel` | `0` means don’t return any warnings; `1`, `2`, `3` will return warnings (if any), with higher numbers corresponding to more warnings
+`timeout` | The time in milliseconds after which the request to the W3C API will be terminated and an error will be thrown
+
+```ts
+const result = await cssValidator.validateURL(cssSourceURL, {
+    medium: 'print',
+    warningLevel: 3,
+    timeout: 3000,
+});
+```
+
+## Response structure
+
+By default, the function returns a Promise, which resolves to an object that looks like:
+
+```ts
+{
+    valid: boolean;
+    errors: {
+        line: number;
+        message: string;
+        url: string | null;
+    }[];
+}
+```
+
+If you ask it to return warnings via `warningLevel`, it will also include a `warnings` key:
+
+```ts
+{
+    ...
+    warnings: {
+        line: number;
+        level: 1 | 2 | 3;
+        message: string;
+        url: string | null;
+    }[];
+}
+```


### PR DESCRIPTION
This merge request implements `validateURL` to validate external CSS sheets with the validator. To accomplish this, I abstracted as much of the shared logic between the existing `validateText` and the new method as possible into helper functions. I also reorganized types into their own directory.

Closes #31 