### PR TITLE
Fix errors thrown in node environments not being caught

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"rugged": "^1.0.0",
 		"ts-jest": "^26.5.2",
 		"ts-node": "^9.1.1",
-		"typescript": "^4.1.3"
+		"typescript": "^4.1.3",
+		"whatwg-fetch": "^3.6.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w3c-css-validator",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Easily validate CSS using W3C's public CSS validator service",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/retrieve-validation/browser.test.ts
+++ b/src/retrieve-validation/browser.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+//Imports
+import retrieveFromBrowser from './browser';
+import 'whatwg-fetch';
+
+// Tests
+describe('#retrieveFromBrowser()', () => {
+	afterEach(
+		() => new Promise<void>((resolve) => setTimeout(resolve, 1000))
+	);
+
+	it('Retrieves the results from the W3C Validator API', async () => {
+		expect(
+			await retrieveFromBrowser(
+				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+				3000
+			)
+		).toStrictEqual({
+			validity: true,
+			checkedby: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+			csslevel: 'css3',
+			date: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+			result: {
+				errorcount: 0,
+				warningcount: 0,
+			},
+			timestamp: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+			uri: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+		});
+	});
+
+	it('Rejects when the request takes longer than the timeout', async () => {
+		await expect(
+			retrieveFromBrowser(
+				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+				1
+			)
+		).rejects.toThrow('The request took longer than 1ms');
+	});
+
+	it('Rejects unexpected errors', async () => {
+		await expect(
+			retrieveFromBrowser(
+				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/xml&profile=css3',
+				3000
+			)
+		).rejects.toThrow();
+	});
+});

--- a/src/retrieve-validation/index-browser.test.ts
+++ b/src/retrieve-validation/index-browser.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// Imports
+import retrieveValidation from '.';
+import retrieveInBrowser from './browser';
+import 'whatwg-fetch';
+
+// Mocks
+jest.mock('./browser');
+
+// Tests
+describe('#retrieveValidation()', () => {
+	it('Uses retrieveInBrowser() when the Fetch API is available', async () => {
+		require('whatwg-fetch');
+
+		await retrieveValidation(
+			'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+			3000
+		);
+
+		expect(retrieveInBrowser as jest.Mock).toBeCalled();
+	});
+});

--- a/src/retrieve-validation/index-node.test.ts
+++ b/src/retrieve-validation/index-node.test.ts
@@ -1,0 +1,18 @@
+// Imports
+import retrieveValidation from '.';
+import retrieveInNode from './node';
+
+// Mocks
+jest.mock('./node');
+
+// Tests
+describe('#retrieveValidation()', () => {
+	it('Uses retrieveInNode() when the Fetch API is not available', async () => {
+		await retrieveValidation(
+			'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+			3000
+		);
+
+		expect(retrieveInNode as jest.Mock).toBeCalled();
+	});
+});

--- a/src/retrieve-validation/node.test.ts
+++ b/src/retrieve-validation/node.test.ts
@@ -1,0 +1,47 @@
+//Imports
+import retrieveFromNode from './node';
+
+// Tests
+describe('#retrieveFromNode()', () => {
+	afterEach(
+		() => new Promise<void>((resolve) => setTimeout(resolve, 1000))
+	);
+
+	it('Retrieves the results from the W3C Validator API', async () => {
+		expect(
+			await retrieveFromNode(
+				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+				3000
+			)
+		).toStrictEqual({
+			validity: true,
+			checkedby: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+			csslevel: 'css3',
+			date: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+			result: {
+				errorcount: 0,
+				warningcount: 0,
+			},
+			timestamp: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+			uri: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+		});
+	});
+
+	it('Rejects when the request takes longer than the timeout', async () => {
+		await expect(
+			retrieveFromNode(
+				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+				1
+			)
+		).rejects.toThrow('The request took longer than 1ms');
+	});
+
+	it('Rejects unexpected errors', async () => {
+		await expect(
+			retrieveFromNode(
+				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/xml&profile=css3',
+				3000
+			)
+		).rejects.toThrow();
+	});
+});

--- a/src/retrieve-validation/node.ts
+++ b/src/retrieve-validation/node.ts
@@ -15,11 +15,19 @@ const retrieveInNode = async (url: string, timeout: number): Promise<W3CCSSValid
 				let data = '';
 
 				res.on('data', (chunk) => {
-					data += chunk;
+					try {
+						data += chunk;
+					} catch (e) {
+						reject(e);
+					}
 				});
 
 				res.on('end', () => {
-					resolve((JSON.parse(data) as W3CCSSValidatorResponse).cssvalidation);
+					try {
+						resolve((JSON.parse(data) as W3CCSSValidatorResponse).cssvalidation);
+					} catch (e) {
+						reject(e);
+					}
 				});
 			}
 		);

--- a/src/retrieve-validation/node.ts
+++ b/src/retrieve-validation/node.ts
@@ -17,8 +17,8 @@ const retrieveInNode = async (url: string, timeout: number): Promise<W3CCSSValid
 				res.on('data', (chunk) => {
 					try {
 						data += chunk;
-					} catch (e) {
-						reject(e);
+					} catch (error) {
+						reject(error);
 					}
 				});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4751,6 +4751,11 @@ whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-fetch@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
 whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"


### PR DESCRIPTION
This pull request fixes a bug where errors thrown inside of `.on` handlers in the node side of handling the response were not being properly rejected and were uncatchable to users of the package.

Closes #93