### PR TITLE
Increase test timeouts

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,7 +11,7 @@ const config: Config.InitialOptions = {
 	resolver: 'jest-ts-webcompat-resolver',
 	testMatch: ['<rootDir>/src/**/*.test.ts'],
 	testEnvironment: 'node',
-	testTimeout: 11000,
+	testTimeout: 15000,
 };
 
 export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,7 @@ const config: Config.InitialOptions = {
 	resolver: 'jest-ts-webcompat-resolver',
 	testMatch: ['<rootDir>/src/**/*.test.ts'],
 	testEnvironment: 'node',
+	testTimeout: 11000,
 };
 
 export default config;

--- a/test-projects/browser/jest.config.ts
+++ b/test-projects/browser/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config.InitialOptions = merge.recursive(presetTSJest, presetJestPu
 	displayName: 'Browser environment',
 	testMatch: ['<rootDir>/*.test.ts'],
 	verbose: true,
+	testTimeout: 11000,
 });
 
 export default config;

--- a/test-projects/browser/jest.config.ts
+++ b/test-projects/browser/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config.InitialOptions = merge.recursive(presetTSJest, presetJestPu
 	displayName: 'Browser environment',
 	testMatch: ['<rootDir>/*.test.ts'],
 	verbose: true,
-	testTimeout: 11000,
+	testTimeout: 15000,
 });
 
 export default config;

--- a/test-projects/node/jest.config.ts
+++ b/test-projects/node/jest.config.ts
@@ -5,7 +5,7 @@ const config: Config.InitialOptions = {
 	verbose: true,
 	preset: 'ts-jest',
 	testMatch: ['<rootDir>/*.test.ts'],
-	testTimeout: 11000,
+	testTimeout: 15000,
 };
 
 export default config;

--- a/test-projects/node/jest.config.ts
+++ b/test-projects/node/jest.config.ts
@@ -5,6 +5,7 @@ const config: Config.InitialOptions = {
 	verbose: true,
 	preset: 'ts-jest',
 	testMatch: ['<rootDir>/*.test.ts'],
+	testTimeout: 11000,
 };
 
 export default config;


### PR DESCRIPTION
This pull request increases the test timeouts above the default timeout for the methods of the package itself. This should make tests more consistent in their passes/failures and also give us a more clear understanding of if the failure is caused by the W3C API taking too long to respond.

Closes #95 