### PR TITLE
Bad status code error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "w3c-css-validator",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Easily validate CSS using W3C's public CSS validator service",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/retrieve-validation/bad-status-error.ts
+++ b/src/retrieve-validation/bad-status-error.ts
@@ -1,0 +1,12 @@
+class BadStatusError extends Error {
+	statusCode: number;
+
+	constructor(message: string, statusCode: number) {
+		super(message);
+
+		this.statusCode = statusCode;
+		this.name = 'BadStatusError';
+	}
+}
+
+export default BadStatusError;

--- a/src/retrieve-validation/browser.ts
+++ b/src/retrieve-validation/browser.ts
@@ -1,5 +1,6 @@
 // Imports
 import { W3CCSSValidatorResponse } from '.';
+import BadStatusError from './bad-status-error';
 
 // Utility function for retrieving response from W3C CSS Validator in a browser environment
 const retrieveInBrowser = async (url: string, timeout: number): Promise<W3CCSSValidatorResponse['cssvalidation']> => {
@@ -16,9 +17,17 @@ const retrieveInBrowser = async (url: string, timeout: number): Promise<W3CCSSVa
 
 	try {
 		res = await fetch(url, { signal: controller.signal });
+
+		if (!res.ok) {
+			throw new BadStatusError(res.statusText, res.status);
+		}
 	} catch (err: unknown) {
 		if (err instanceof Error && err.name === 'AbortError') {
 			throw new Error(`The request took longer than ${timeout}ms`);
+		}
+
+		if (err instanceof TypeError) {
+			throw new TypeError(`${err.message} (This may be due to trying to validate too much CSS at once)`);
 		}
 
 		throw err;

--- a/src/retrieve-validation/node.test.ts
+++ b/src/retrieve-validation/node.test.ts
@@ -1,4 +1,5 @@
 //Imports
+import BadStatusError from './bad-status-error';
 import retrieveFromNode from './node';
 
 // Tests
@@ -34,6 +35,28 @@ describe('#retrieveFromNode()', () => {
 				1
 			)
 		).rejects.toThrow('The request took longer than 1ms');
+	});
+
+	it('Rejects status codes other than 200-300', async () => {
+		try {
+			await retrieveFromNode(
+				`https://jigsaw.w3.org/css-validator/validator?text=${encodeURIComponent(
+					'* { color: black }\n'.repeat(750)
+				)}&usermedium=all&warning=no&output=application/json&profile=css3`,
+				3000
+			);
+
+			throw new Error('This test should not proceed to this point');
+		} catch (error: unknown) {
+			expect(error).toBeInstanceOf(BadStatusError);
+
+			if (!(error instanceof BadStatusError)) {
+				return;
+			}
+
+			expect(error.message).toBe('Bad request (This may be due to trying to validate too much CSS at once)');
+			expect(error.statusCode).toBe(400);
+		}
 	});
 
 	it('Rejects unexpected errors', async () => {

--- a/src/retrieve-validation/node.ts
+++ b/src/retrieve-validation/node.ts
@@ -1,6 +1,7 @@
 // Imports
 import * as https from 'https';
 import { W3CCSSValidatorResponse } from '.';
+import BadStatusError from './bad-status-error';
 
 // Utility function for retrieving response from W3C CSS Validator in a Node.js environment
 const retrieveInNode = async (url: string, timeout: number): Promise<W3CCSSValidatorResponse['cssvalidation']> => {
@@ -12,6 +13,18 @@ const retrieveInNode = async (url: string, timeout: number): Promise<W3CCSSValid
 				timeout,
 			},
 			(res) => {
+				if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode > 300)) {
+					let message = res.statusMessage;
+
+					if (res.statusCode === 400) {
+						message = message
+							? `${message} (This may be due to trying to validate too much CSS at once)`
+							: 'This may be due to trying to validate too much CSS at once';
+					}
+
+					reject(new BadStatusError(message ?? '', res.statusCode));
+				}
+
 				let data = '';
 
 				res.on('data', (chunk) => {

--- a/src/retrieve-validation/node.ts
+++ b/src/retrieve-validation/node.ts
@@ -13,7 +13,7 @@ const retrieveInNode = async (url: string, timeout: number): Promise<W3CCSSValid
 				timeout,
 			},
 			(res) => {
-				if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode > 300)) {
+				if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode >= 300)) {
 					let message = res.statusMessage;
 
 					if (res.statusCode === 400) {


### PR DESCRIPTION
In this pull request I added behavior to make sure we were throwing errors when a response had a bad status, and appended a message to some errors warning users of the package about trying to validate too much raw CSS.

Closes #98 