### PR TITLE
Move parameter processing to one centralized location

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -2,5 +2,8 @@
 	"extends": ["plugin:@typescript-eslint/recommended-requiring-type-checking", "../eslint.base.json"],
 	"parserOptions": {
 		"project": ["./tsconfig.json"]
+	},
+	"rules": {
+		"@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }]
 	}
 }

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -2,8 +2,5 @@
 	"extends": ["plugin:@typescript-eslint/recommended-requiring-type-checking", "../eslint.base.json"],
 	"parserOptions": {
 		"project": ["./tsconfig.json"]
-	},
-	"rules": {
-		"@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }]
 	}
 }

--- a/src/build-request-url.test.ts
+++ b/src/build-request-url.test.ts
@@ -41,9 +41,9 @@ describe('#buildRequestURL()', () => {
 
 	it('Complains if text and URL values are provided simultaneously', () => {
 		expect(() =>
+			// @ts-expect-error: We're trying to force an error here
 			buildRequestURL({
 				text: '.foo { text-align: center; }',
-				// @ts-expect-error: We're trying to force an error here
 				url: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
 				medium: undefined,
 				warningLevel: undefined,

--- a/src/retrieve-validation/index-browser.test.ts
+++ b/src/retrieve-validation/index-browser.test.ts
@@ -17,7 +17,11 @@ describe('#retrieveValidation()', () => {
 
 		await retrieveValidation(
 			'GET',
-			'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+			{
+				text: '.foo { text-align: center; }',
+				medium: undefined,
+				warningLevel: undefined,
+			},
 			3000
 		);
 

--- a/src/retrieve-validation/index-node.test.ts
+++ b/src/retrieve-validation/index-node.test.ts
@@ -10,7 +10,11 @@ describe('#retrieveValidation()', () => {
 	it('Uses retrieveInNode() when the Fetch API is not available', async () => {
 		await retrieveValidation(
 			'GET',
-			'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+			{
+				text: '.foo { text-align: center; }',
+				medium: undefined,
+				warningLevel: undefined,
+			},
 			3000
 		);
 

--- a/src/retrieve-validation/index.ts
+++ b/src/retrieve-validation/index.ts
@@ -30,9 +30,11 @@ const retrieveValidation = async (
 	timeout: number
 ): Promise<W3CCSSValidatorResponse['cssvalidation']> => {
 	// Validate options
-	const { text: _text, url: _url, ...options } = unprocessedParameters;
-
-	validateOptions(options);
+	validateOptions({
+		timeout,
+		medium: unprocessedParameters.medium,
+		warningLevel: unprocessedParameters.warningLevel,
+	});
 
 	// Build request URL
 	const url = buildRequestURL(unprocessedParameters);

--- a/src/retrieve-validation/index.ts
+++ b/src/retrieve-validation/index.ts
@@ -42,7 +42,7 @@ const retrieveValidation = async (
 		return await retrieveInBrowser(method, url, timeout);
 	}
 
-	// Retrieve response in node environments
+	// Retrieve response in Node.js environments
 	return await retrieveInNode(method, url, timeout);
 };
 

--- a/src/retrieve-validation/index.ts
+++ b/src/retrieve-validation/index.ts
@@ -1,4 +1,7 @@
 // Imports
+import buildRequestURL from '../build-request-url';
+import { Parameters } from '../types/parameters';
+import validateOptions from '../validate-options';
 import retrieveInBrowser from './browser';
 import retrieveInNode from './node';
 
@@ -23,13 +26,23 @@ export interface W3CCSSValidatorResponse {
 // Function that detects the appropriate HTTP request client and returns a response accordingly
 const retrieveValidation = async (
 	method: 'GET',
-	url: string,
+	unprocessedParameters: Parameters,
 	timeout: number
 ): Promise<W3CCSSValidatorResponse['cssvalidation']> => {
+	// Validate options
+	const { text: _text, url: _url, ...options } = unprocessedParameters;
+
+	validateOptions(options);
+
+	// Build request URL
+	const url = buildRequestURL(unprocessedParameters);
+
+	// Retrieve response in browser environments
 	if (typeof window !== 'undefined' && typeof window?.fetch === 'function') {
 		return await retrieveInBrowser(method, url, timeout);
 	}
 
+	// Retrieve response in node environments
 	return await retrieveInNode(method, url, timeout);
 };
 

--- a/src/types/parameters.ts
+++ b/src/types/parameters.ts
@@ -7,7 +7,7 @@ interface ParametersBase {
 
 interface TextParameters extends ParametersBase {
 	text: string;
-	uri?: never;
+	url?: never;
 }
 
 interface URLParameters extends ParametersBase {

--- a/src/validate-text.ts
+++ b/src/validate-text.ts
@@ -1,5 +1,4 @@
 // Imports
-import buildRequestURL from './build-request-url';
 import retrieveValidation from './retrieve-validation';
 import { OptionsWithoutWarnings, OptionsWithWarnings, Options } from './types/options';
 import {
@@ -8,7 +7,6 @@ import {
 	ValidateTextResult,
 	ValidateTextResultBase,
 } from './types/result';
-import validateOptions from './validate-options';
 
 // Validates a string of CSS
 async function validateText(
@@ -29,17 +27,16 @@ async function validateText(textToBeValidated: string, options?: Options): Promi
 		throw new Error('The text to be validated must be a string');
 	}
 
-	validateOptions(options);
-
-	// Build URL for fetching
-	const url = buildRequestURL({
-		text: textToBeValidated,
-		medium: options?.medium,
-		warningLevel: options?.warningLevel,
-	});
-
 	// Call W3C CSS Validator API and store response
-	const cssValidationResponse = await retrieveValidation('GET', url, options?.timeout ?? 10000);
+	const cssValidationResponse = await retrieveValidation(
+		'GET',
+		{
+			text: textToBeValidated,
+			medium: options?.medium,
+			warningLevel: options?.warningLevel,
+		},
+		options?.timeout ?? 10000
+	);
 
 	// Build result
 	const base: ValidateTextResultBase = {

--- a/src/validate-url.ts
+++ b/src/validate-url.ts
@@ -1,5 +1,4 @@
 // Imports
-import buildRequestURL from './build-request-url';
 import retrieveValidation from './retrieve-validation';
 import { OptionsWithoutWarnings, OptionsWithWarnings, Options } from './types/options';
 import {
@@ -8,7 +7,6 @@ import {
 	ValidateURLResult,
 	ValidateURLResultBase,
 } from './types/result';
-import validateOptions from './validate-options';
 
 // Validates a string of CSS
 async function validateURL(
@@ -29,17 +27,16 @@ async function validateURL(urlToBeValidated: string, options?: Options): Promise
 		throw new Error('The URL to be validated must be a string');
 	}
 
-	validateOptions(options);
-
-	// Build URL for fetching
-	const url = buildRequestURL({
-		url: urlToBeValidated,
-		medium: options?.medium,
-		warningLevel: options?.warningLevel,
-	});
-
 	// Call W3C CSS Validator API and store response
-	const cssValidationResponse = await retrieveValidation('GET', url, options?.timeout ?? 10000);
+	const cssValidationResponse = await retrieveValidation(
+		'GET',
+		{
+			url: urlToBeValidated,
+			medium: options?.medium,
+			warningLevel: options?.warningLevel,
+		},
+		options?.timeout ?? 10000
+	);
 
 	// Build result
 	const base: ValidateURLResultBase = {


### PR DESCRIPTION
In preparation for more complicated parameter processing resolving #115, this pull request moves parameter processing into one centralized location used by every kind of request.

There were some ancillary changes, I fixed a type bug that was using the wrong property name in the parameter types, which lead to moving a `ts-expect-error` a few lines up where it belonged to begin with. I also modified an eslint rule to enable removing values from an object via destructuring.