### PR TITLE
Built framework for processing different parameter types based on request method

### DIFF
--- a/src/retrieve-validation/browser.test.ts
+++ b/src/retrieve-validation/browser.test.ts
@@ -17,7 +17,7 @@ describe('#retrieveFromBrowser()', () => {
 		expect(
 			await retrieveFromBrowser(
 				'GET',
-				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+				'?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
 				3000
 			)
 		).toStrictEqual({
@@ -38,7 +38,7 @@ describe('#retrieveFromBrowser()', () => {
 		await expect(
 			retrieveFromBrowser(
 				'GET',
-				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+				'?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
 				1
 			)
 		).rejects.toThrow('The request took longer than 1ms');
@@ -48,7 +48,7 @@ describe('#retrieveFromBrowser()', () => {
 		try {
 			await retrieveFromBrowser(
 				'GET',
-				`https://jigsaw.w3.org/css-validator/validator?usermedium=all&warning=no&output=application/json&profile=css3`,
+				`?usermedium=all&warning=no&output=application/json&profile=css3`,
 				3000
 			);
 
@@ -68,7 +68,7 @@ describe('#retrieveFromBrowser()', () => {
 		await expect(
 			retrieveFromBrowser(
 				'GET',
-				`https://jigsaw.w3.org/css-validator/validator?text=${encodeURIComponent(
+				`?text=${encodeURIComponent(
 					'* { color: black }\n'.repeat(750)
 				)}&usermedium=all&warning=no&output=application/json&profile=css3`,
 				3000
@@ -80,7 +80,7 @@ describe('#retrieveFromBrowser()', () => {
 		await expect(
 			retrieveFromBrowser(
 				'GET',
-				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/xml&profile=css3',
+				'?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/xml&profile=css3',
 				3000
 			)
 		).rejects.toThrow();

--- a/src/retrieve-validation/browser.ts
+++ b/src/retrieve-validation/browser.ts
@@ -5,7 +5,7 @@ import BadStatusError from './bad-status-error';
 // Utility function for retrieving response from W3C CSS Validator in a browser environment
 const retrieveInBrowser = async (
 	method: 'GET',
-	url: string,
+	parameters: string,
 	timeout: number
 ): Promise<W3CCSSValidatorResponse['cssvalidation']> => {
 	// Initialize controller who's signal will abort the fetch
@@ -20,7 +20,10 @@ const retrieveInBrowser = async (
 	let res: Response | null = null;
 
 	try {
-		res = await fetch(url, { method, signal: controller.signal });
+		res = await fetch(`https://jigsaw.w3.org/css-validator/validator${method === 'GET' ? parameters : ''}`, {
+			method,
+			signal: controller.signal,
+		});
 
 		if (!res.ok) {
 			throw new BadStatusError(res.statusText, res.status);

--- a/src/retrieve-validation/build-request-url-parameters.test.ts
+++ b/src/retrieve-validation/build-request-url-parameters.test.ts
@@ -1,48 +1,48 @@
 // Imports
-import buildRequestURL from './build-request-url';
+import buildRequestURLParameters from './build-request-url-parameters';
 
 // Tests
-describe('#buildRequestURL()', () => {
+describe('#buildRequestURLParameters()', () => {
 	it('Handles parameters with text value', () => {
 		expect(
-			buildRequestURL({
+			buildRequestURLParameters({
 				text: '.foo { text-align: center; }',
 				medium: undefined,
 				warningLevel: undefined,
 			})
 		).toBe(
-			'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3'
+			'?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3'
 		);
 	});
 
 	it('Handles parameters with URL value', () => {
 		expect(
-			buildRequestURL({
+			buildRequestURLParameters({
 				url: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
 				medium: undefined,
 				warningLevel: undefined,
 			})
 		).toBe(
-			'https://jigsaw.w3.org/css-validator/validator?uri=https%3A%2F%2Fraw.githubusercontent.com%2Fsparksuite%2Fw3c-css-validator%2Fmaster%2Fpublic%2Fcss%2Fvalid.css&usermedium=all&warning=no&output=application/json&profile=css3'
+			'?uri=https%3A%2F%2Fraw.githubusercontent.com%2Fsparksuite%2Fw3c-css-validator%2Fmaster%2Fpublic%2Fcss%2Fvalid.css&usermedium=all&warning=no&output=application/json&profile=css3'
 		);
 	});
 
 	it('Uses provided parameters over default values', () => {
 		expect(
-			buildRequestURL({
+			buildRequestURLParameters({
 				text: '.foo { text-align: center; }',
 				medium: 'braille',
 				warningLevel: 3,
 			})
 		).toBe(
-			'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=braille&warning=2&output=application/json&profile=css3'
+			'?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=braille&warning=2&output=application/json&profile=css3'
 		);
 	});
 
 	it('Complains if text and URL values are provided simultaneously', () => {
 		expect(() =>
 			// @ts-expect-error: We're trying to force an error here
-			buildRequestURL({
+			buildRequestURLParameters({
 				text: '.foo { text-align: center; }',
 				url: 'https://raw.githubusercontent.com/sparksuite/w3c-css-validator/master/public/css/valid.css',
 				medium: undefined,

--- a/src/retrieve-validation/build-request-url-parameters.ts
+++ b/src/retrieve-validation/build-request-url-parameters.ts
@@ -1,8 +1,8 @@
 // Imports
-import { Parameters } from './types/parameters';
+import { Parameters } from '../types/parameters';
 
 // Helper function that takes in parameters and builds a URL to make a request with
-function buildRequestURL(parameters: Parameters): string {
+function buildRequestURLParameters(parameters: Parameters): string {
 	// Validate input
 	if ('text' in parameters && 'url' in parameters) {
 		throw new Error('Only a text or a URL value can be provided');
@@ -23,9 +23,9 @@ function buildRequestURL(parameters: Parameters): string {
 		profile: 'css3',
 	};
 
-	return `https://jigsaw.w3.org/css-validator/validator?${Object.entries(params)
+	return `?${Object.entries(params)
 		.map(([key, val]) => `${key}=${val}`)
 		.join('&')}`;
 }
 
-export default buildRequestURL;
+export default buildRequestURLParameters;

--- a/src/retrieve-validation/index.ts
+++ b/src/retrieve-validation/index.ts
@@ -1,9 +1,9 @@
 // Imports
-import buildRequestURL from '../build-request-url';
 import { Parameters } from '../types/parameters';
 import validateOptions from '../validate-options';
 import retrieveInBrowser from './browser';
 import retrieveInNode from './node';
+import processParameters from './process-parameters';
 
 // Define types
 export interface W3CCSSValidatorResponse {
@@ -36,16 +36,16 @@ const retrieveValidation = async (
 		warningLevel: unprocessedParameters.warningLevel,
 	});
 
-	// Build request URL
-	const url = buildRequestURL(unprocessedParameters);
+	// Process request parameters
+	const parameters = processParameters(method, unprocessedParameters);
 
 	// Retrieve response in browser environments
 	if (typeof window !== 'undefined' && typeof window?.fetch === 'function') {
-		return await retrieveInBrowser(method, url, timeout);
+		return await retrieveInBrowser(method, parameters, timeout);
 	}
 
 	// Retrieve response in Node.js environments
-	return await retrieveInNode(method, url, timeout);
+	return await retrieveInNode(method, parameters, timeout);
 };
 
 export default retrieveValidation;

--- a/src/retrieve-validation/node.test.ts
+++ b/src/retrieve-validation/node.test.ts
@@ -12,7 +12,7 @@ describe('#retrieveFromNode()', () => {
 		expect(
 			await retrieveFromNode(
 				'GET',
-				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+				'?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
 				3000
 			)
 		).toStrictEqual({
@@ -33,7 +33,7 @@ describe('#retrieveFromNode()', () => {
 		await expect(
 			retrieveFromNode(
 				'GET',
-				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
+				'?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/json&profile=css3',
 				1
 			)
 		).rejects.toThrow('The request took longer than 1ms');
@@ -43,7 +43,7 @@ describe('#retrieveFromNode()', () => {
 		try {
 			await retrieveFromNode(
 				'GET',
-				`https://jigsaw.w3.org/css-validator/validator?text=${encodeURIComponent(
+				`?text=${encodeURIComponent(
 					'* { color: black }\n'.repeat(750)
 				)}&usermedium=all&warning=no&output=application/json&profile=css3`,
 				3000
@@ -66,7 +66,7 @@ describe('#retrieveFromNode()', () => {
 		await expect(
 			retrieveFromNode(
 				'GET',
-				'https://jigsaw.w3.org/css-validator/validator?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/xml&profile=css3',
+				'?text=.foo%20%7B%20text-align%3A%20center%3B%20%7D&usermedium=all&warning=no&output=application/xml&profile=css3',
 				3000
 			)
 		).rejects.toThrow();

--- a/src/retrieve-validation/node.ts
+++ b/src/retrieve-validation/node.ts
@@ -6,13 +6,13 @@ import BadStatusError from './bad-status-error';
 // Utility function for retrieving response from W3C CSS Validator in a Node.js environment
 const retrieveInNode = async (
 	method: 'GET',
-	url: string,
+	parameters: string,
 	timeout: number
 ): Promise<W3CCSSValidatorResponse['cssvalidation']> => {
 	return new Promise((resolve, reject) => {
 		// Attempt to fetch CSS validation
 		const req = https.request(
-			url,
+			`https://jigsaw.w3.org/css-validator/validator${method === 'GET' ? parameters : ''}`,
 			{
 				method,
 				timeout,

--- a/src/retrieve-validation/process-parameters.test.ts
+++ b/src/retrieve-validation/process-parameters.test.ts
@@ -1,0 +1,16 @@
+// Imports
+import buildRequestURLParameters from "./build-request-url-parameters";
+import processParameters from "./process-parameters";
+
+// Tests
+describe('#processParameters()', () => {
+	it('Returns URL parameters for GET requests', () => {
+        const parameters = {
+            text: '.foo { text-align: center; }',
+            medium: undefined,
+            warningLevel: undefined,
+        };
+
+		expect(processParameters('GET', parameters)).toBe(buildRequestURLParameters(parameters));
+	});
+});

--- a/src/retrieve-validation/process-parameters.ts
+++ b/src/retrieve-validation/process-parameters.ts
@@ -1,0 +1,18 @@
+// Imports
+import retrieveValidation from '.';
+import buildRequestURLParameters from './build-request-url-parameters';
+import { Parameters as RequestParameters } from '../types/parameters';
+
+// Function that processes parameters into the correct data type / structure based on the request method
+const processParameters = (method: Parameters<typeof retrieveValidation>[0], parameters: RequestParameters): string => {
+	// Handle parameters for GET method
+	if (method === 'GET') {
+		return buildRequestURLParameters(parameters);
+	}
+
+	// Throw if an unrecognized parameter is provided
+	// eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- This should be unreachable
+	throw new Error(`Parameter processing called with unrecognized method: ${method}`);
+};
+
+export default processParameters;


### PR DESCRIPTION
In this merge request I prepared for having multiple parameter data types in resolving #115, to accomplish that i changed the way the URL was being built for `GET` requests to just be a static base for every kind of request, and append URL parameters if its a `GET` request. In connection, I modified `buildRequestURL` to just return the search parameters as a string, instead of the whole URL. Lastly I made a new function, `processParameters` that is meant to be the single source for logic dedicated to processing parameters for every kind of request.
