### PR TITLE
Fix mistakenly overriding button styles

### DIFF
--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -42,3 +42,7 @@
 	background: #fff;
 	color: #000;
 }
+
+.getStarted:hover {
+	filter: brightness(90%);
+}

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -36,7 +36,8 @@
 	width: 200px;
 }
 
-.getStarted {
+.getStarted,
+.getStarted:hover {
 	border: none;
 	background: #fff;
 	color: #000;


### PR DESCRIPTION
I added a selector that matches the specificity of the mistakenly overriding CSS rule, and added a darkening effect on hover to maintain some consistency with buttons on other pages of the docs website.

![](https://images.sparksuite.com/j/HiAbLpN2JyIkeWFdrYZs+/GIF+Recording+2023-01-30+at+1.55.26+PM.gif)

Closes #145 
