### PR TITLE
Use `yarn dev` to standardize with other config files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,7 @@ jobs:
         with:
           node-version: lts/*
           cache: 'yarn'
-      - run: yarn install --frozen-lockfile --prefer-offline
-      - run: yarn compile
-      - run: yarn --cwd ./website install --frozen-lockfile --prefer-offline
+      - run: yarn dev
       - run: yarn --cwd ./website type-check
       - run: yarn --cwd ./website build
   publish:


### PR DESCRIPTION
This PR uses `yarn dev` in place of individual commands that accomplish the same thing, to keep the file consistent with other Sparksuite OSS repositories.